### PR TITLE
upgrade to @rollup/pluginsutils

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,6 @@
 import { Plugin, TransformPluginContext, TransformResult } from "rollup";
 import { minify, MinifyOptions } from "terser";
-import { createFilter } from "rollup-pluginutils";
+import { createFilter } from '@rollup/pluginutils';
 
 export interface IUglifyOptions extends MinifyOptions {
   include?: string | RegExp;


### PR DESCRIPTION
plugin still references rollup-pluginutils 

rollup-pluginutils was moved and is now available at @rollup/pluginutils. The old one have to be removed from package.json

Thank you for your contribution to the get-internal-type repo. 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] You have added unit tests
