### PR TITLE
Makes pluginutils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "dist"
   ],
   "dependencies": {
+    "@rollup/pluginutils": "^4.2.1",
     "core-js": "^3.24.1"
   },
   "devDependencies": {
-    "@rollup/pluginutils": "^4.2.1",
     "@types/jest": "^28.1.7",
     "@types/rollup": "^0.54.0",
     "@types/rollup-plugin-commonjs": "^9.3.1",


### PR DESCRIPTION
This resolves issue #13 where the plugin will have an error unless @rollup/pluginutils is installed as a devDependency in the project using this plugin. 

with `@rollup/pluginutils` as a dependency, it will install with this plugin and users of the package will be able to avoid this error. 

I have confirmed this project builds and all unit tests pass. I didn't add any unit tests because I'm not sure exactly how to write a unit test for this. 
